### PR TITLE
Fixes disabling context menu for right clicking the one square

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@
   const oneSquare = document.querySelector(".one-square");
 
   let startTime, animationFrame;
-  let last = "";
 
   startTimer();
 

--- a/style.css
+++ b/style.css
@@ -136,7 +136,13 @@ section {
 }
 
 .flagged {
-  pointer-events: none;
+  /* 
+   *  If we set pointer-events to none here, the logic to disable the context menu
+   *  on right clicking the one square fails, because this class takes effect before
+   *  the event fires, causing the contextmenu event to bubble to the parent div
+   *
+   *  @see https://github.com/tholman/one-square-minesweeper/issues/1
+   */
   background-image: url("./img/cell-flagged.png");
 }
 


### PR DESCRIPTION
This fixes https://github.com/tholman/one-square-minesweeper/issues/1, in which the context menu is firing when right clicking the one square.

The existing logic has:
```
  document.oncontextmenu = function (e) {
    if (e.target === oneSquare) return false;
  };
```

Which should work in theory, but in practice it wasn't. I discovered that, even when clicking the square, `e.target` was the *outer div* (`board-items`). It took me a bit to figure out why, but eventually I noticed how `pointer-events: none;` was set on the `flagged` class. If I remove that, the `oncontextmenu` event target is correctly `one-square`.

This is kind of weird, since the right click event precedes adding the `flagged` class. I guess `oncontextmenu` fires after `mouseup`, and by the time it fires the class is already applies and the pointer event passes through to the parent div. It's possible that this only happens on faster machines or some modern browser versions, maybe the CSS change parsing was delayed for some reason in your development context? I'm curious how reproducible this issue is.

I don't know the initial rationale for setting pointer-events to none for `flagged`, maybe prior logic broke if it was clicked again but you updated it? Regardless, I played around a bit with it after making this change, and I don't notice any changing behavior besides the context menu fix.

Anyhow, this is a cool project, and I absolutely love [theuselessweb.com](https://theuselessweb.com/).